### PR TITLE
feat: Switch vulkan images to the kompute backend

### DIFF
--- a/chat/setup.sh
+++ b/chat/setup.sh
@@ -2,5 +2,9 @@ git clone https://github.com/abetlen/llama-cpp-python --no-checkout --recurse-su
 cd llama-cpp-python
 git checkout v0.3.2
 git submodule update
+pushd vendor/llama.cpp
+git submodule init
+git submodule update
+popd
 git fetch origin pull/1552/head
 git rebase ffc47e5a95cf31fe6d9d6d7953d5eb17fdcc8513

--- a/chat/vulkan/amd64/Containerfile
+++ b/chat/vulkan/amd64/Containerfile
@@ -24,7 +24,7 @@ RUN dnf install -y python3-dnf-plugin-versionlock && \
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf install -y git cmake ninja-build gcc gcc-c++ && \
     dnf copr enable -y ligenix/enterprise-sandbox epel-9-x86_64 && \
-    dnf install -y vulkan-headers vulkan-tools vulkan-loader-devel && \
+    dnf install -y vulkan-headers vulkan-tools vulkan-loader-devel fmt-devel && \
     dnf copr enable -y ligenix/enterprise-buildtools epel-9-x86_64 && \
     dnf copr enable -y jeffmaury/shaderc epel-9-x86_64 && \
     dnf install -y glslc && \
@@ -34,7 +34,7 @@ WORKDIR /locallm
 COPY requirements.txt ./
 COPY llama-cpp-python llama-cpp-python
 RUN pip install --upgrade pip
-ENV CMAKE_ARGS="-DGGML_VULKAN=on"
+ENV CMAKE_ARGS="-DGGML_KOMPUTE=1 -DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF"
 ENV FORCE_CMAKE=1
 RUN pip install --target=/locallm --no-cache-dir --upgrade -r requirements.txt
 

--- a/chat/vulkan/arm64/Containerfile
+++ b/chat/vulkan/arm64/Containerfile
@@ -25,14 +25,14 @@ https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf copr enable -y slp/mesa-krunkit epel-9-aarch64 && \
     dnf install -y mesa-vulkan-drivers-24.1.2-101.el9.aarch64 && \
     dnf versionlock  mesa-vulkan-drivers-24.1.2-101.el9.aarch64 && \
-    dnf install -y git cmake ninja-build gcc gcc-c++ vulkan-loader-devel vulkan-tools && \
+    dnf install -y git cmake ninja-build gcc gcc-c++ vulkan-loader-devel vulkan-tools fmt-devel && \
     dnf copr enable -y jeffmaury/shaderc epel-9-aarch64 && \
     dnf install -y glslc && \
     dnf clean all
 COPY requirements.txt ./
 COPY llama-cpp-python llama-cpp-python
 RUN pip install --upgrade pip
-ENV CMAKE_ARGS="-DGGML_VULKAN=on"
+ENV CMAKE_ARGS="-DGGML_KOMPUTE=1 -DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF"
 ENV FORCE_CMAKE=1
 RUN pip install --target=/locallm --no-cache-dir --upgrade -r requirements.txt
 


### PR DESCRIPTION
The latest versions of MoltenVK (tested with 1.2.11) are not able to deal properly with llama.cpp's Vulkan (GGML_VULKAN) backend.

Switch our Vulkan images to use the Kompute (GGML_KOMPUTE) backend instead, which works fine with MoltenVK and will eventually achieve the same performance as Metal on macOS bare-metal.